### PR TITLE
Defaults reflect out of the box ACPI handling

### DIFF
--- a/acpi-eeepc-generic.conf
+++ b/acpi-eeepc-generic.conf
@@ -122,11 +122,15 @@ WIFI_DRIVERS=("rt2860sta")
 BLUETOOTH_DRIVERS=("bluetooth")
 CAMERA_DRIVERS=("uvcvideo")
 # Let acpi-eeepc-generic load/unload modules?
-#DRIVERS_LOAD="no"      # default: yes
-#DRIVERS_UNLOAD="no"    # default: yes
+# The unloading is not needed anymore to block wifi as kernel `rfkill` subsystem works out of the box
+# Comment out only if `rfkill list` doesn't show that Wifi is disabled and re-enabled on keypress
+DRIVERS_LOAD="no"      # default: yes
+DRIVERS_UNLOAD="no"    # default: yes
 
 #################################################################
 ### Volume options
+# Check if volume up, down and mute keys work without an explicit handler
+# before resorting to this option
 ALSA_VOLUME_MIXER=("Master") # Mixer(s) to change volume
 
 #################################################################
@@ -135,7 +139,10 @@ ALSA_VOLUME_MIXER=("Master") # Mixer(s) to change volume
 ### Some defaults are provided, but they might not work on your
 ### system if you don't have the utility installed.
 
-COMMANDS_POWER_BUTTON=("/sbin/shutdown -t3 -h now")
+# Power button is handled by systemd. See https://wiki.archlinux.org/index.php/Power_management
+# if you need to change the default behavior
+# COMMANDS_POWER_BUTTON is only useful if you disable systemd handling it
+#COMMANDS_POWER_BUTTON=("/sbin/shutdown -t3 -h now")
 # Users of LXDE might consider the following:
 #COMMANDS_POWER_BUTTON=("@_LXSESSION_PID=`pidof lxsession` lxde-logout")
 # See http://code.google.com/p/acpi-eeepc-generic/issues/detail?id=26
@@ -148,18 +155,24 @@ COMMANDS_POWER_BUTTON=("/sbin/shutdown -t3 -h now")
 # of this, theese commands will be executed as yourself and not root.
 # The User1, User2 & User3 (when available) are executed as your username!!!
 COMMANDS_BUTTON_BLANK=("xset dpms force off")
-COMMANDS_BUTTON_RESOLUTION=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-touchpad.sh")
+COMMANDS_BUTTON_RESOLUTION=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-resolution.sh")
 COMMANDS_BUTTON_USER1=("@terminal")
 COMMANDS_BUTTON_USER2=("@pcmanfm --no-desktop")
 
+# SHE stands for Super Hybrid Engine. It is usually triggered by Fn + Space
+# It lets you save power by reducing CPU clock speed
 COMMANDS_SHE_TOGGLE=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-she.sh")
 
-COMMANDS_SLEEP=("/etc/acpi/eeepc/acpi-eeepc-generic-suspend2ram.sh")
+# See COMMANDS_POWER_BUTTON comment above. This option isn't usually needed
+# as sleeping work out of the box on systemd systems
+#COMMANDS_SLEEP=("/etc/acpi/eeepc/acpi-eeepc-generic-suspend2ram.sh")
 # On some models, calling the wifi toggle script can prevent the card from
 # being re-enabled. If you have that problem, just don't call the script and
 # let the BIOS dis/enable the card.
 # See http://wiki.github.com/nbigaouette/acpi-eeepc-generic/wireless
-COMMANDS_WIFI_TOGGLE=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-wifi.sh")
+# Wifi toggling should work out of the box including wifi light
+# Only use the option if it doesn't
+#COMMANDS_WIFI_TOGGLE=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-wifi.sh")
 COMMANDS_WIFI_UP=()
 COMMANDS_WIFI_DOWN=()
 COMMANDS_WIFI_PRE_UP=()
@@ -168,7 +181,9 @@ COMMANDS_WIFI_PRE_UP=()
 COMMANDS_WIFI_POST_UP=()
 COMMANDS_WIFI_PRE_DOWN=()
 COMMANDS_WIFI_POST_DOWN=()
-COMMANDS_BLUETOOTH_TOGGLE=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-bluetooth.sh")
+# See COMMANDS_WIFI_TOGGLE comment above. Only use the option if `rfkill list` doesn't show 
+# Bluetooth disabled and re-enabled
+#COMMANDS_BLUETOOTH_TOGGLE=("/etc/acpi/eeepc/acpi-eeepc-generic-toggle-bluetooth.sh")
 COMMANDS_BLUETOOTH_UP=()
 COMMANDS_BLUETOOTH_DOWN=()
 COMMANDS_BLUETOOTH_PRE_UP=()
@@ -189,13 +204,16 @@ COMMANDS_TASKM=("@lxtask")
 #COMMANDS_TASKM=("@ksysguard")
 
 # If you use OSS, you can use http://ossvol.sourceforge.net/
-COMMANDS_MUTE=("alsa_toggle_mute")
-COMMANDS_VOLUME_DOWN=("alsa_set_volume 5%-")
-COMMANDS_VOLUME_UP=("alsa_set_volume 5%+")
+# With ALSA and PulseAudio the volume controls should work out of the box
+# Only uncomment the commands below if they don't
+#COMMANDS_MUTE=("alsa_toggle_mute")
+#COMMANDS_VOLUME_DOWN=("alsa_set_volume 5%-")
+#COMMANDS_VOLUME_UP=("alsa_set_volume 5%+")
 
 COMMANDS_AC_UNPLUGGED=()
 COMMANDS_AC_PLUGGED=()
-COMMANDS_ON_LID_CLOSE="yes"
+# Lid switch is handled by systemd. See COMMANDS_POWER_BUTTON comment above
+COMMANDS_ON_LID_CLOSE="no"
 COMMANDS_LID_CLOSE_ON_AC=("xset dpms force off")        # Just turn the backlight off
 #COMMANDS_LID_CLOSE_ON_AC=("${COMMANDS_SLEEP[@]}")      # Do the same as COMMANDS_SLEEP
 COMMANDS_LID_CLOSE_ON_BATTERY=("${COMMANDS_SLEEP[@]}")  # Do the same as COMMANDS_SLEEP
@@ -205,7 +223,8 @@ COMMANDS_LID_CLOSE_ON_BATTERY=("${COMMANDS_SLEEP[@]}")  # Do the same as COMMAND
 ### Check for these processes before suspending
 SUSPEND_BLACKLISTED_PROCESSES=(vlc mplayer smplayer kmplayer skype dragon songbird-bin amarok)
 ### Change the suspend commands.
-SUSPEND2RAM_COMMANDS=("echo -n \"mem\" > /sys/power/state") # Simple suspend
+# Suspension is handled by systemd. See COMMANDS_POWER_BUTTON comment above
+#SUSPEND2RAM_COMMANDS=("echo -n \"mem\" > /sys/power/state") # Simple suspend
 #SUSPEND2RAM_COMMANDS=("pm-suspend") # Use pm-utils
 #SUSPEND_QUIRKS_VTSWITCH="yes"
 


### PR DESCRIPTION
The changeset is large just to show that almost everything is handled these days by default even without `acpid`. Notable exceptions are SHE and touchpad.

Of course it is a good idea to test the config on more than one system so feel free to add LGTM if it works for you.